### PR TITLE
WordPress bundle: add an 'outputs' section

### DIFF
--- a/bundle-trusty-wordpress/bundle-trusty-wordpress.heat.yml
+++ b/bundle-trusty-wordpress/bundle-trusty-wordpress.heat.yml
@@ -90,3 +90,12 @@ resources:
     properties:
       floating_ip: { get_resource: floating_ip }
       server_id: { get_resource: server }
+
+outputs:
+  wordpress_url:
+    description: WordPress URL
+    value:
+      str_replace:
+        template: http://$HOST/
+        params:
+          "$HOST": { get_attr: [floating_ip, floating_ip_address] }


### PR DESCRIPTION
Add an 'outputs' section in the heat template to provide a clickable link
in the UI (floating IP information).
